### PR TITLE
Start running tests immediately

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -30,7 +30,6 @@ jobs:
       run: tox -e ${{ matrix.tox-env }}
 
   test:
-    needs: lint
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The test configuration currently blocks running unit tests until linting is done. This was probably present in an example we copied to avoid running potentially expensive tests until relatively quick linting checks are complete, however in our case the tests themselves are also quick so we might as well start running them immediately.